### PR TITLE
Also find sourceMappingURL= comments in the middle

### DIFF
--- a/source-map-url.js
+++ b/source-map-url.js
@@ -25,7 +25,7 @@ void (function(root, factory) {
       "|" +
       "//(?:" + innerRegex.source + ")" +
     ")" +
-    "\\s*$"
+    "\\s*(?:$|(?:" + newlineRegex.source + "))"
   )
 
   function SourceMappingURL(commentSyntax) {


### PR DESCRIPTION
not just at the last line of the code. Strictly speaking,
sourceMappingURL= comments have to appear at the end of the file as the
last line. However, for this module to be more useful, I relaxed the
regex a bit. Ideally, we could provide an option to users whether it
should strictly stay with the specification, or pragmatically look at
the entire code for the comments.
