### PR TITLE
Switch to esm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - "12.20.0"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### unreleased (yyy-mm-dd) ###
+- Switched to ESM
+
 ### Version 0.4.1 (2021-02-01) ###
 
 - Improved: The package is now about 50% smaller, by excluding unnecessary

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "author": "Simon Lydell",
   "license": "MIT",
+  "type": "module",
   "description": "Tools for working with sourceMappingURL comments.",
   "keywords": [
     "source map",
@@ -10,6 +11,9 @@
     "comment",
     "annotation"
   ],
+  "engines": {
+    "node": ">=12.20.0"
+  },
   "main": "source-map-url.js",
   "repository": "lydell/source-map-url",
   "scripts": {
@@ -18,9 +22,9 @@
     "test": "npm run lint && npm run unit"
   },
   "devDependencies": {
-    "mocha": "~1.17.1",
-    "expect.js": "~0.3.1",
-    "jshint": "~2.4.3"
+    "expect.js": "^0.3.1",
+    "jshint": "^2.13.0",
+    "mocha": "^9.0.3"
   },
   "testling": {
     "harness": "mocha",

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ Overview [![Build Status](https://travis-ci.org/lydell/source-map-url.png?branch
 Tools for working with sourceMappingURL comments.
 
 ```js
-var sourceMappingURL = require("source-map-url")
+import sourceMappingURL from "source-map-url"
 
 var code = [
   "!function(){...}();",

--- a/source-map-url.js
+++ b/source-map-url.js
@@ -1,57 +1,51 @@
 // Copyright 2014 Simon Lydell
 // X11 (“MIT”) Licensed. (See LICENSE.)
 
-void (function(root, factory) {
-  if (typeof define === "function" && define.amd) {
-    define(factory)
-  } else if (typeof exports === "object") {
-    module.exports = factory()
-  } else {
-    root.sourceMappingURL = factory()
-  }
-}(this, function() {
+const innerRegex = /[#@] sourceMappingURL=([^\s'"]*)/
 
-  var innerRegex = /[#@] sourceMappingURL=([^\s'"]*)/
+const regex = RegExp(
+  '(?:' +
+    '/\\*' +
+    '(?:\\s*\r?\n(?://)?)?' +
+    '(?:' + innerRegex.source + ')' +
+    '\\s*' +
+    '\\*/' +
+    '|' +
+    '//(?:' + innerRegex.source + ')' +
+  ')' +
+  '\\s*'
+)
 
-  var regex = RegExp(
-    "(?:" +
-      "/\\*" +
-      "(?:\\s*\r?\n(?://)?)?" +
-      "(?:" + innerRegex.source + ")" +
-      "\\s*" +
-      "\\*/" +
-      "|" +
-      "//(?:" + innerRegex.source + ")" +
-    ")" +
-    "\\s*"
-  )
+export default {
+  regex,
+  _innerRegex: innerRegex,
 
-  return {
+  /** @param {string} code */
+  getFrom (code) {
+    const match = code.match(regex)
+    return (match ? match[1] || match[2] || '' : null)
+  },
 
-    regex: regex,
-    _innerRegex: innerRegex,
+  /** @param {string} code */
+  existsIn (code) {
+    return regex.test(code)
+  },
 
-    getFrom: function(code) {
-      var match = code.match(regex)
-      return (match ? match[1] || match[2] || "" : null)
-    },
+  /** @param {string} code */
+  removeFrom (code) {
+    return code.replace(regex, '')
+  },
 
-    existsIn: function(code) {
-      return regex.test(code)
-    },
-
-    removeFrom: function(code) {
-      return code.replace(regex, "")
-    },
-
-    insertBefore: function(code, string) {
-      var match = code.match(regex)
-      if (match) {
-        return code.slice(0, match.index) + string + code.slice(match.index)
-      } else {
-        return code + string
-      }
+  /**
+   * @param {string} code
+   * @param {string} string
+   */
+  insertBefore (code, string) {
+    const match = code.match(regex)
+    if (match) {
+      return code.slice(0, match.index) + string + code.slice(match.index)
+    } else {
+      return code + string
     }
   }
-
-}));
+}

--- a/test/source-map-url.js
+++ b/test/source-map-url.js
@@ -1,402 +1,346 @@
 // Copyright 2014 Simon Lydell
 // X11 (“MIT”) Licensed. (See LICENSE.)
 
-var expect = require("expect.js")
+import expect from 'expect.js'
+import sourceMappingURL from '../source-map-url.js'
 
-var sourceMappingURL = require("../")
-
-var comments = {
+const comments = {
 
   universal: [
-    "/*# sourceMappingURL=foo.js.map */"
+    '/*# sourceMappingURL=foo.js.map */'
   ],
 
   js: [
-    "//# sourceMappingURL=foo.js.map"
+    '//# sourceMappingURL=foo.js.map'
   ],
 
   block: [
-    "/*",
-    "# sourceMappingURL=foo.js.map",
-    "*/"
+    '/*',
+    '# sourceMappingURL=foo.js.map',
+    '*/'
   ],
 
   mix: [
-    "/*",
-    "//# sourceMappingURL=foo.js.map",
-    "*/"
+    '/*',
+    '//# sourceMappingURL=foo.js.map',
+    '*/'
   ]
 
 }
 
-var nonTrailingComments = {
+const nonTrailingComments = {
 
   jsLeading: {
     contents: [
-      "//# sourceMappingURL=foo.js.map",
-      "(function(){})"
+      '//# sourceMappingURL=foo.js.map',
+      '(function(){})'
     ],
     solution: [
-      "(function(){})"
+      '(function(){})'
     ]
   },
 
   mixEmbedded: {
     contents: [
-      "/*! Library Name v1.0.0",
-      "//# sourceMappingURL=foo.js.map",
-      "*/",
-      "(function(){})"
+      '/*! Library Name v1.0.0',
+      '//# sourceMappingURL=foo.js.map',
+      '*/',
+      '(function(){})'
     ],
     solution: [
-      "/*! Library Name v1.0.0",
-      "*/",
-      "(function(){})"
+      '/*! Library Name v1.0.0',
+      '*/',
+      '(function(){})'
     ]
   }
 
 }
 
-function forEachComment(fn) {
-  forOf(comments, function(name, comment) {
-    var description = "the '" + name + "' syntax with "
-    fn(comment.join("\n"),   description + "regular newlines")
-    fn(comment.join("\r\n"), description + "Windows newlines")
+function forEachComment (fn) {
+  forOf(comments, (name, comment) => {
+    const description = `the '${name}' syntax with `
+    fn(comment.join('\n'), `${description}regular newlines`)
+    fn(comment.join('\r\n'), `${description}Windows newlines`)
   })
 }
 
-function forEachNonTrailingComment(fn) {
-  forOf(nonTrailingComments, function(name, comment) {
-
-    var description = "the '" + name + "' syntax with "
-
-    fn({
-      contents: comment.contents.join("\n"),
-      solution: comment.solution.join("\n")
-    }, description + "regular newlines")
+function forEachNonTrailingComment (fn) {
+  forOf(nonTrailingComments, (name, comment) => {
+    const description = `the '${name}' syntax with `
 
     fn({
-      contents: comment.contents.join("\r\n"),
-      solution: comment.solution.join("\r\n")
-    }, description + "Windows newlines")
+      contents: comment.contents.join('\n'),
+      solution: comment.solution.join('\n')
+    }, `${description}regular newlines`)
+
+    fn({
+      contents: comment.contents.join('\r\n'),
+      solution: comment.solution.join('\r\n')
+    }, `${description}Windows newlines`)
   })
 }
 
-function forOf(obj, fn) {
-  for (var key in obj) {
+function forOf (obj, fn) {
+  for (const key in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, key)) {
       fn(key, obj[key])
     }
   }
 }
 
+describe('sourceMappingURL', () => {
+  describe('.getFrom', () => {
+    forEachComment((comment, description) => {
+      it(`gets the url from ${description}`, () => {
+        expect(sourceMappingURL.getFrom(`code\n${comment}`))
+          .to.equal('foo.js.map')
 
-describe("sourceMappingURL", function() {
-
-  describe(".getFrom", function() {
-
-    forEachComment(function(comment, description) {
-
-      it("gets the url from " + description, function() {
-        expect(sourceMappingURL.getFrom("code\n" + comment))
-          .to.equal("foo.js.map")
-
-        expect(sourceMappingURL.getFrom("code" + comment))
-          .to.equal("foo.js.map")
+        expect(sourceMappingURL.getFrom(`code${comment}`))
+          .to.equal('foo.js.map')
 
         expect(sourceMappingURL.getFrom(comment))
-          .to.equal("foo.js.map")
+          .to.equal('foo.js.map')
       })
-
     })
 
-    forEachNonTrailingComment(function(comment, description) {
+    forEachNonTrailingComment((comment, description) => {
+      it(`gets the url from ${description}`, () => {
+        expect(sourceMappingURL.getFrom(`code\n${comment.contents}`))
+          .to.equal('foo.js.map')
 
-      it("gets the url from " + description, function() {
-        expect(sourceMappingURL.getFrom("code\n" + comment.contents))
-          .to.equal("foo.js.map")
-
-        expect(sourceMappingURL.getFrom("code" + comment.contents))
-          .to.equal("foo.js.map")
+        expect(sourceMappingURL.getFrom(`code${comment.contents}`))
+          .to.equal('foo.js.map')
 
         expect(sourceMappingURL.getFrom(comment.contents))
-          .to.equal("foo.js.map")
+          .to.equal('foo.js.map')
       })
-
     })
 
-
-    it("returns null if no comment", function() {
-      expect(sourceMappingURL.getFrom("code"))
+    it('returns null if no comment', () => {
+      expect(sourceMappingURL.getFrom('code'))
         .to.equal(null)
     })
 
-
-    it("can return an empty string as url", function() {
-      expect(sourceMappingURL.getFrom("/*# sourceMappingURL= */"))
-        .to.equal("")
+    it('can return an empty string as url', () => {
+      expect(sourceMappingURL.getFrom('/*# sourceMappingURL= */'))
+        .to.equal('')
     })
 
-
-    it("is detachable", function() {
-      var get = sourceMappingURL.getFrom
-      expect(get("/*# sourceMappingURL=foo */"))
-        .to.equal("foo")
+    it('is detachable', () => {
+      const get = sourceMappingURL.getFrom
+      expect(get('/*# sourceMappingURL=foo */'))
+        .to.equal('foo')
     })
-
   })
 
-
-  describe(".existsIn", function() {
-
-    forEachComment(function(comment, description) {
-
-      it("returns true for " + description, function() {
-        expect(sourceMappingURL.existsIn("code\n" + comment))
+  describe('.existsIn', () => {
+    forEachComment((comment, description) => {
+      it(`returns true for ${description}`, () => {
+        expect(sourceMappingURL.existsIn(`code\n${comment}`))
           .to.equal(true)
 
-        expect(sourceMappingURL.existsIn("code" + comment))
+        expect(sourceMappingURL.existsIn(`code${comment}`))
           .to.equal(true)
 
         expect(sourceMappingURL.existsIn(comment))
           .to.equal(true)
       })
-
     })
 
-    forEachNonTrailingComment(function(comment, description) {
-
-      it("returns true for " + description, function() {
-        expect(sourceMappingURL.existsIn("code\n" + comment.contents))
+    forEachNonTrailingComment((comment, description) => {
+      it(`returns true for ${description}`, () => {
+        expect(sourceMappingURL.existsIn(`code\n${comment.contents}`))
           .to.equal(true)
 
-        expect(sourceMappingURL.existsIn("code" + comment.contents))
+        expect(sourceMappingURL.existsIn(`code${comment.contents}`))
           .to.equal(true)
 
         expect(sourceMappingURL.existsIn(comment.contents))
           .to.equal(true)
       })
-
     })
 
-
-    it("returns false if no comment", function() {
-      expect(sourceMappingURL.existsIn("code"))
+    it('returns false if no comment', () => {
+      expect(sourceMappingURL.existsIn('code'))
         .to.equal(false)
     })
 
-
-    it("is detachable", function() {
-      var has = sourceMappingURL.existsIn
-      expect(has("/*# sourceMappingURL=foo */"))
+    it('is detachable', () => {
+      const has = sourceMappingURL.existsIn
+      expect(has('/*# sourceMappingURL=foo */'))
         .to.equal(true)
     })
-
   })
 
+  describe('.removeFrom', () => {
+    forEachComment((comment, description) => {
+      it(`removes the comment for ${description}`, () => {
+        expect(sourceMappingURL.removeFrom(`code\n${comment}`))
+          .to.equal('code\n')
 
-  describe(".removeFrom", function() {
-
-    forEachComment(function(comment, description) {
-
-      it("removes the comment for " + description, function() {
-        expect(sourceMappingURL.removeFrom("code\n" + comment))
-          .to.equal("code\n")
-
-        expect(sourceMappingURL.removeFrom("code" + comment))
-          .to.equal("code")
+        expect(sourceMappingURL.removeFrom(`code${comment}`))
+          .to.equal('code')
 
         expect(sourceMappingURL.removeFrom(comment))
-          .to.equal("")
+          .to.equal('')
       })
-
     })
 
-    forEachNonTrailingComment(function(comment, description) {
+    forEachNonTrailingComment((comment, description) => {
+      it(`removes the comment for ${description}`, () => {
+        expect(sourceMappingURL.removeFrom(`code\n${comment.contents}`))
+          .to.equal(`code\n${comment.solution}`)
 
-      it("removes the comment for " + description, function() {
-        expect(sourceMappingURL.removeFrom("code\n" + comment.contents))
-          .to.equal("code\n" + comment.solution)
-
-        expect(sourceMappingURL.removeFrom("code" + comment.contents))
-          .to.equal("code" + comment.solution)
+        expect(sourceMappingURL.removeFrom(`code${comment.contents}`))
+          .to.equal(`code${comment.solution}`)
 
         expect(sourceMappingURL.removeFrom(comment.contents))
           .to.equal(comment.solution)
       })
-
     })
 
-
-    it("does nothing if no comment", function() {
-      expect(sourceMappingURL.removeFrom("code\n"))
-        .to.equal("code\n")
+    it('does nothing if no comment', () => {
+      expect(sourceMappingURL.removeFrom('code\n'))
+        .to.equal('code\n')
     })
 
-
-    it("is detachable", function() {
-      var remove = sourceMappingURL.removeFrom
-      expect(remove("/*# sourceMappingURL=foo */"))
-        .to.equal("")
+    it('is detachable', () => {
+      const remove = sourceMappingURL.removeFrom
+      expect(remove('/*# sourceMappingURL=foo */'))
+        .to.equal('')
     })
-
   })
 
+  describe('.insertBefore', () => {
+    forEachComment((comment, description) => {
+      it(`inserts a string before the comment for ${description}`, () => {
+        expect(sourceMappingURL.insertBefore(`code\n${comment}`, 'more code\n'))
+          .to.equal(`code\nmore code\n${comment}`)
 
-  describe(".insertBefore", function() {
+        expect(sourceMappingURL.insertBefore(`code${comment}`, '\nmore code'))
+          .to.equal(`code\nmore code${comment}`)
 
-    forEachComment(function(comment, description) {
-
-      it("inserts a string before the comment for " + description, function() {
-        expect(sourceMappingURL.insertBefore("code\n" + comment, "more code\n"))
-          .to.equal("code\nmore code\n" + comment)
-
-        expect(sourceMappingURL.insertBefore("code" + comment, "\nmore code"))
-          .to.equal("code\nmore code" + comment)
-
-        expect(sourceMappingURL.insertBefore(comment, "some code"))
-          .to.equal("some code" + comment)
+        expect(sourceMappingURL.insertBefore(comment, 'some code'))
+          .to.equal(`some code${comment}`)
       })
-
     })
 
-
-    it("inserts a string before an embedded comment", function() {
-      expect(sourceMappingURL.insertBefore("/*! Library Name v1.0.0\n" +
-        "//# sourceMappingURL=foo.js.map\n*/\n(function(){})", "code\n"))
-        .to.equal("/*! Library Name v1.0.0\ncode\n" +
-          "//# sourceMappingURL=foo.js.map\n*/\n(function(){})")
+    it('inserts a string before an embedded comment', () => {
+      expect(sourceMappingURL.insertBefore('/*! Library Name v1.0.0\n' +
+        '//# sourceMappingURL=foo.js.map\n*/\n(function(){})', 'code\n'))
+        .to.equal('/*! Library Name v1.0.0\ncode\n' +
+          '//# sourceMappingURL=foo.js.map\n*/\n(function(){})')
     })
 
-
-    it("inserts a string before a leading comment", function() {
-      expect(sourceMappingURL.insertBefore("//# sourceMappingURL=foo.js.map\n" +
-        "(function(){})", "code\n"))
-        .to.equal("code\n//# sourceMappingURL=foo.js.map\n" +
-          "(function(){})")
+    it('inserts a string before a leading comment', () => {
+      expect(sourceMappingURL.insertBefore('//# sourceMappingURL=foo.js.map\n' +
+        '(function(){})', 'code\n'))
+        .to.equal('code\n//# sourceMappingURL=foo.js.map\n' +
+          '(function(){})')
     })
 
-
-    it("appends if no comment", function() {
-      expect(sourceMappingURL.insertBefore("code", "\nmore code"))
-        .to.equal("code\nmore code")
+    it('appends if no comment', () => {
+      expect(sourceMappingURL.insertBefore('code', '\nmore code'))
+        .to.equal('code\nmore code')
     })
 
-
-    it("is detachable", function() {
-      var insertBefore = sourceMappingURL.insertBefore
-      expect(insertBefore("/*# sourceMappingURL=foo */", "bar"))
-        .to.equal("bar/*# sourceMappingURL=foo */")
+    it('is detachable', () => {
+      const insertBefore = sourceMappingURL.insertBefore
+      expect(insertBefore('/*# sourceMappingURL=foo */', 'bar'))
+        .to.equal('bar/*# sourceMappingURL=foo */')
     })
-
   })
 
-
-  describe(".regex", function() {
-
-    it("includes ._innerRegex", function() {
+  describe('.regex', () => {
+    it('includes ._innerRegex', () => {
       expect(sourceMappingURL.regex.source)
         .to.contain(sourceMappingURL._innerRegex.source)
     })
 
-
-    var match = function(code) {
+    const match = code => {
       expect(code)
         .to.match(sourceMappingURL.regex)
     }
 
-    var noMatch = function(code) {
+    const noMatch = code => {
       expect(code)
         .not.to.match(sourceMappingURL.regex)
     }
 
-
-    forEachComment(function(comment, description) {
-
-      it("matches " + description, function() {
-        match("code\n" + comment)
-        match("code" + comment)
+    forEachComment((comment, description) => {
+      it(`matches ${description}`, () => {
+        match(`code\n${comment}`)
+        match(`code${comment}`)
         match(comment)
       })
 
-
-      it("matches " + description + ", with trailing whitespace", function() {
-        match(comment + "  ")
-        match(comment + "\n")
-        match(comment + "\n\n\t\n    \t  ")
+      it(`matches ${description}, with trailing whitespace`, () => {
+        match(`${comment}  `)
+        match(`${comment}\n`)
+        match(`${comment}\n\n\t\n    \t  `)
       })
-
     })
 
-
-    it("does not match some cases that are easy to mess up", function() {
+    it('does not match some cases that are easy to mess up', () => {
       noMatch(
-        "/* # sourceMappingURL=foo */"
+        '/* # sourceMappingURL=foo */'
       )
 
       noMatch(
-        "// # sourceMappingURL=foo"
+        '// # sourceMappingURL=foo'
       )
     })
 
-
-    it("is liberal regarding inner whitespace", function() {
+    it('is liberal regarding inner whitespace', () => {
       match(
-        "/*# sourceMappingURL=foo*/"
+        '/*# sourceMappingURL=foo*/'
       )
 
       match(
-        "/*# sourceMappingURL=foo    */"
+        '/*# sourceMappingURL=foo    */'
       )
 
       match(
-        "/*# sourceMappingURL=foo   \t\n" +
-        "*/"
+        '/*# sourceMappingURL=foo   \t\n' +
+        '*/'
       )
 
       match(
-        "/*    \n" +
-        "# sourceMappingURL=foo\n" +
-        "*/"
+        '/*    \n' +
+        '# sourceMappingURL=foo\n' +
+        '*/'
       )
 
       match(
-        "/*\n" +
-        "# sourceMappingURL=foo\n" +
-        "     */"
+        '/*\n' +
+        '# sourceMappingURL=foo\n' +
+        '     */'
       )
 
       match(
-        "/*\n" +
-        "# sourceMappingURL=foo\n" +
-        "\n" +
-        "\t\n" +
-        "*/"
+        '/*\n' +
+        '# sourceMappingURL=foo\n' +
+        '\n' +
+        '\t\n' +
+        '*/'
       )
     })
-
   })
 
-
-  describe("._innerRegex", function() {
-
-    it("matches the contents of sourceMappingURL comments", function() {
-      expect("# sourceMappingURL=http://www.example.com/foo/bar.js.map")
+  describe('._innerRegex', () => {
+    it('matches the contents of sourceMappingURL comments', () => {
+      expect('# sourceMappingURL=http://www.example.com/foo/bar.js.map')
         .to.match(sourceMappingURL._innerRegex)
     })
 
-
-    it("captures the url in the first capture group", function() {
-      expect(sourceMappingURL._innerRegex.exec("# sourceMappingURL=foo")[1])
-        .to.equal("foo")
+    it('captures the url in the first capture group', () => {
+      expect(sourceMappingURL._innerRegex.exec('# sourceMappingURL=foo')[1])
+        .to.equal('foo')
     })
 
-
-    it("supports the legacy syntax", function() {
-      expect("@ sourceMappingURL=http://www.example.com/foo/bar.js.map")
+    it('supports the legacy syntax', () => {
+      expect('@ sourceMappingURL=http://www.example.com/foo/bar.js.map')
         .to.match(sourceMappingURL._innerRegex)
     })
-
   })
-
 })


### PR DESCRIPTION
Hope u don't mind if i executed `standard --fix` style looked similar, it changed all stuff to const/let/arrow fn etc

thrown in some jsdoc also to help with typing

makes for better cross comp code in deno & browser without npm/bundler